### PR TITLE
Adding media location.

### DIFF
--- a/tutordiscovery/patches/nginx-extra
+++ b/tutordiscovery/patches/nginx-extra
@@ -37,4 +37,8 @@ server {
   location /static {
     alias /var/www/discovery/assets; 
   }
+  
+  location /media {
+    alias /var/www/discovery/media; 
+  }
 }


### PR DESCRIPTION
When trying to setup an image in a course metadata, nginx can't resolve the request to fetch the file.

One way to reproduce this issue, is to setup discovery, then go to http://discovery.localhost/admin/course_metadata/course/1/change/ change the course image and try to access the uploaded image, in my case: http://discovery.localhost/media/media/course/image/5d07b45a-1da2-4f23-8c65-3f81263bb024-34cfe8f2a782.jpg will fail to retrieve.

I _think_ that this is because the nginx location for media is missing.

I didn't confirm this yet, but I think that ecommerce will have the same issue as we don't have a mapping for /media, if you configure stripe it will try to fetch the image url that was received from discovery service, in my local testing is trying to fetch from ecommerce, so it will also fail.