### PR TITLE
Add local nginx aliase.

### DIFF
--- a/tutordiscovery/patches/local-docker-compose-nginx-aliases
+++ b/tutordiscovery/patches/local-docker-compose-nginx-aliases
@@ -1,0 +1,1 @@
+- {{ DISCOVERY_HOST }}


### PR DESCRIPTION
Add local nginx aliase to allow access discovery service through
discovery.local.overhang.io when running locally.