### PR TITLE
Set studio-url at initialisation

### DIFF
--- a/tutordiscovery/templates/discovery/hooks/discovery/init
+++ b/tutordiscovery/templates/discovery/hooks/discovery/init
@@ -6,6 +6,7 @@ make migrate
   --site-domain {{ DISCOVERY_HOST }}:8381 \
   --code dev --name "Open edX - development" \
   --lms-url="http://lms:8000" \
+  --studio-url="http://cms:8000" \
   --courses-api-url "http://{{ LMS_HOST }}:8000/api/courses/v1/" \
   --organizations-api-url "http://{{ LMS_HOST }}:8000/api/organizations/v1/"
 
@@ -15,6 +16,7 @@ make migrate
   --site-domain {{ DISCOVERY_HOST }} \
   --code openedx --name "Open edX" \
   --lms-url="http://lms:8000" \
+  --studio-url="http://cms:8000" \
   --courses-api-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/api/courses/v1/" \
   --organizations-api-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/api/organizations/v1/"
 


### PR DESCRIPTION
A PR to set the studio URL at initialisation. This makes the discovery plugin more ready out of the box for other services (e.g. publisher MFE). 

See [thread](https://discuss.overhang.io/t/updating-base-configuration-for-tutor-discovery/1963/3).

@overhangio/tutor-developers this is ready for review.