### PR TITLE
Fix API URLs for tutor local environment

### DIFF
--- a/tutordiscovery/templates/discovery/hooks/discovery/init
+++ b/tutordiscovery/templates/discovery/hooks/discovery/init
@@ -7,8 +7,8 @@ make migrate
   --code dev --name "Open edX - development" \
   --lms-url="http://lms:8000" \
   --studio-url="http://cms:8000" \
-  --courses-api-url "http://{{ LMS_HOST }}:8000/api/courses/v1/" \
-  --organizations-api-url "http://{{ LMS_HOST }}:8000/api/organizations/v1/"
+  --courses-api-url "http://{{ LMS_HOST }}/api/courses/v1/" \
+  --organizations-api-url "http://{{ LMS_HOST }}/api/organizations/v1/"
 
 # Production partner
 ./manage.py create_or_update_partner  \


### PR DESCRIPTION
By default, {{ LMS_HOST }} resolves to local.overflow.io, which is accessed on default http port 80 rather than port 8000

Resolves https://github.com/overhangio/tutor-discovery/issues/25