### PR TITLE
feat: open stdin & allocate tty on dev services

### DIFF
--- a/tutordiscovery/patches/local-docker-compose-dev-services
+++ b/tutordiscovery/patches/local-docker-compose-dev-services
@@ -2,6 +2,8 @@ discovery:
   environment:
     DJANGO_SETTINGS_MODULE: course_discovery.settings.tutor.development
   command: ./manage.py runserver 0.0.0.0:8381
+  stdin_open: true
+  tty: true
   ports:
     - "8381:8381"
   networks:


### PR DESCRIPTION
This ensures that services started with `tutor dev start`
are as capable for breakpoint debugging, et al, as services
started with `tutor dev runserver` are. We plan to remove
`tutor dev runserver`.

Blocks https://github.com/overhangio/tutor/pull/644