### PR TITLE
docs: change quickstart to launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Then, run migrations::
 
     tutor local init
 
-This last step is unnecessary if you run instead ``tutor local quickstart``.
+This last step is unnecessary if you run instead ``tutor local launch``.
 
 Operations
 ----------


### PR DESCRIPTION
This change is due to renaming quickstart to launch in tutor.
See https://github.com/overhangio/tutor/pull/724