### PR TITLE
fix(build): load NPM_REGISTRY from config

### DIFF
--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH /openedx/nodeenv/bin:${PATH}
 # This is identical to "make production-requirements" but it was split in multiple
 # instructions to benefit from docker image caching
 RUN pip install -r requirements.txt
-ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 RUN npm install --verbose --registry=$NPM_REGISTRY --production
 RUN ./node_modules/.bin/bower install --allow-root --production
 


### PR DESCRIPTION
Makes it possible to build the `discovery` image with a custom NPM_REGISTRY url.
Same fix filed for other plugins.

FYI @regisb