### PR TITLE
feat: extra pip requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,18 @@ Then::
 
 This last step should be performed every time you create new or make changes to existing programs.
 
+Install extra requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to install extra requirements, use DISCOVERY_EXTRA_PIP_REQUIREMENTS and re-build the docker image.::
+
+  tutor config save \
+    --set 'DISCOVERY_EXTRA_PIP_REQUIREMENTS=["git+https://github.com/myusername/myplugin"]'
+
+Then, build the image, pointing to your fork if necessary::
+
+  tutor images build discovery
+
 Debugging
 ---------
 

--- a/tutordiscovery/plugin.py
+++ b/tutordiscovery/plugin.py
@@ -28,6 +28,7 @@ config = {
         "OAUTH2_KEY_SSO": "discovery-sso",
         "OAUTH2_KEY_SSO_DEV": "discovery-sso-dev",
         "CACHE_REDIS_DB": "{{ OPENEDX_CACHE_REDIS_DB }}",
+        "EXTRA_PIP_REQUIREMENTS": [],
     },
 }
 

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -38,6 +38,9 @@ ENV PATH /openedx/nodeenv/bin:${PATH}
 # This is identical to "make production-requirements" but it was split in multiple
 # instructions to benefit from docker image caching
 RUN pip install -r requirements.txt
+{% for extra_requirements in DISCOVERY_EXTRA_PIP_REQUIREMENTS %}RUN pip install '{{ extra_requirements }}'
+{% endfor %}
+
 ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 RUN npm install --verbose --registry=$NPM_REGISTRY --production
 RUN ./node_modules/.bin/bower install --allow-root --production


### PR DESCRIPTION
Add option to install extra pip requirements.

As part of implementing event_bus_redis, we want the ability to install event_bus_redis in discovery if required. This would allow us to remove kafka and redis event bus deps from discovery and install only if required.