### PR TITLE
feat: add minimal `atlas` step to the build FC-0012

### DIFF
--- a/changelog.d/20230909_160414_i_atlas.md
+++ b/changelog.d/20230909_160414_i_atlas.md
@@ -1,0 +1,1 @@
+- [Feature] Pull translations via `atlas` during Docker build. (by @OmarIthawi)

--- a/tutordiscovery/plugin.py
+++ b/tutordiscovery/plugin.py
@@ -31,6 +31,7 @@ config = {
         "OAUTH2_KEY_SSO": "discovery-sso",
         "OAUTH2_KEY_SSO_DEV": "discovery-sso-dev",
         "CACHE_REDIS_DB": "{{ OPENEDX_CACHE_REDIS_DB }}",
+        "ATLAS_PULL": False,
         "EXTRA_PIP_REQUIREMENTS": [],
     },
 }

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked{% endif %} \
     apt update && \
-    apt install -y curl git-core language-pack-en python3 python3-dev python3-pip python3-venv \
+    apt install -y curl git-core gettext language-pack-en python3 python3-dev python3-pip python3-venv \
     build-essential libcairo2 libffi-dev libmysqlclient-dev libxml2-dev libxslt-dev libjpeg-dev libssl-dev \
     pkg-config
 ENV LC_ALL en_US.UTF-8
@@ -61,7 +61,15 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/openedx/.cache/pip,
     # Use redis as a django cache https://pypi.org/project/django-redis/
     django-redis==5.2.0 \
     # uwsgi server https://pypi.org/project/uWSGI/
-    uwsgi==2.0.21
+    uwsgi==2.0.21 \
+    # Open edX Atlas tranlsation management tool https://pypi.org/project/openedx-atlas/
+    openedx-atlas==0.5.0
+
+{% if DISCOVERY_ATLAS_PULL %}
+# Pull translations. Support the OEP-58 proposal behind a feature flag until it's fully implemented.
+RUN atlas pull {{ patch("atlas-extra-args") }} translations/course-discovery/course_discovery/conf/locale:course_discovery/conf/locale
+RUN python manage.py compilemessages
+{% endif %}
 
 # Collect static assets
 COPY --chown=app:app assets.py ./course_discovery/settings/assets.py


### PR DESCRIPTION
Add https://github.com/openedx/openedx-atlas to the Dockerfile and run the `atlas pull` command on every build.

I'm starting here because this is a simple plugin and helps us to design it properly. The end goal is to add `atlas` on all other components including edX Platform, MFEs and possibly even ecommerce.

This is a very minimal build that needs the following to be viable:

 - Ability to configure the repo, branch and other options.
 - Possibly make it a system-wide pattern in tutor instead of adding it to individual components.

This PR requires the following branch of discovery: https://github.com/openedx/course-discovery/pull/4037


### TODO

 - [ ] ~Implement https://github.com/openedx/openedx-atlas/issues/17~
 - [ ] ~Implement https://github.com/openedx/openedx-atlas/issues/30~
 - [x] Update the version in this repo
 - [x] Add a single `DISCOVERY_ATLAS_OPTOINS` variable to keep it minimal
 - [x] Build the docker image and test 
 - [x] Ensure messages gets compiled correctly: https://github.com/openedx/openedx-translations/pull/564

<details><summary>Building and testing logs</summary>

```
# Set the following variables:
# DISCOVERY_ATLAS_ARGS: --filter=ar,de
# DISCOVERY_ATLAS_PULL: true

$ tutor config save
$ tutor images build discovery
Building image docker.io/overhangio/openedx-discovery:16.0.0
....
$ docker run -it docker.io/overhangio/openedx-discovery:16.0.0 atlas --version
v0.4.4
```

Check the file tree

```
$ docker run -it docker.io/overhangio/openedx-discovery:16.0.0 ls -R course_discovery/conf/locale/
course_discovery/conf/locale/:
ar  config.yaml  de

course_discovery/conf/locale/ar:
LC_MESSAGES

course_discovery/conf/locale/ar/LC_MESSAGES:
djangojs.po  django.po

course_discovery/conf/locale/de:
LC_MESSAGES

course_discovery/conf/locale/de/LC_MESSAGES:
djangojs.po  django.po
```

Verify translations within the image:

```
$ docker run -it docker.io/overhangio/openedx-discovery:16.0.0 cat course_discovery/conf/locale/de/LC_MESSAGES/django.po | head -n 100
# #-#-#-#-#  django.po (course-discovery)  #-#-#-#-#
# edX translation file
# Copyright (C) 2018 edX
# This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
# 
# Translators:
# Translators:
# Omar Al-Ithawi <i@omardo.com>, 2023
# 
msgid ""
msgstr ""
"Project-Id-Version: edx-platform\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2023-08-03 00:22+0000\n"
"PO-Revision-Date: 2023-01-26 15:39+0000\n"
"Last-Translator: Omar Al-Ithawi <i@omardo.com>, 2023\n"
"Language-Team: German (https://app.transifex.com/open-edx/teams/147691/de/)\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Language: de\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"

#: apps/api/filters.py:47
#, python-brace-format
msgid "No user with the username [{username}] exists."
msgstr "Ein Nutzer mit Namen [{username}] existiert nicht."

#: apps/api/filters.py:50
msgid ""
"Only staff users are permitted to filter by username. Remove the username "
"parameter."
msgstr ""
"Nur Mitarbeiter sind berechtigt nach Benutzernamen zu filtern. Entfernen Sie"
" den Benutzername Parameter"

#: apps/api/serializers.py:813
msgid "Number of courses contained in this catalog"
msgstr "Anzahl der Kurse in diesem Katalog"

#: apps/api/serializers.py:816
msgid "Usernames of users with explicit access to view this catalog"
msgstr ""
"Benutzernamen der Nutzer mit ausdrücklichem Zugriff um diesen Katalog zu "
"sehen"

#: apps/api/serializers.py:976
msgid "Start date cannot be after the End date"
msgstr "Startdatum kann nicht nach dem Enddatum gesetzt werden"

#: apps/api/serializers.py:981
msgid "Term cannot be changed"
msgstr "Begriff kann nicht geändert werden"

#: apps/api/serializers.py:993
msgid "Language in which the course is administered"
msgstr "Sprache in der dieser Kurs verwaltet wird"

.....

```
</details> 

# Background
This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).