### PR TITLE
chore: use course-discovery openedx-atlas requirement | FC-0012

### DIFF
--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -61,9 +61,7 @@ RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/openedx/.cache/pip,
     # Use redis as a django cache https://pypi.org/project/django-redis/
     django-redis==5.2.0 \
     # uwsgi server https://pypi.org/project/uWSGI/
-    uwsgi==2.0.21 \
-    # Open edX Atlas tranlsation management tool https://pypi.org/project/openedx-atlas/
-    openedx-atlas==0.5.0
+    uwsgi==2.0.21
 
 {% if DISCOVERY_ATLAS_PULL %}
 # Pull translations. Support the OEP-58 proposal behind a feature flag until it's fully implemented.


### PR DESCRIPTION
 [course-discovery now maintains its own base.in requirement for atlas](https://github.com/openedx/course-discovery/pull/4117/files#diff-eec14310e29cef9d8ae421c606788e73774112c68cda8ab743ad4257ff73d156R562) the tutor-discovery no longer needs to install it.


### TODO

 - [x] Rebuild the image
 - [x] Test to ensure `openedx-atlas==0.5.0` is still installed

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
