### PR TITLE
Add mounts for docker-compose-dev-services

### DIFF
--- a/changelog.d/20240220_173703_cmltawt0_mounts.md
+++ b/changelog.d/20240220_173703_cmltawt0_mounts.md
@@ -1,0 +1,1 @@
+- [Feature] Make it possible to use mounts for a local development. (by @cmltawt0)

--- a/tutordiscovery/patches/local-docker-compose-dev-services
+++ b/tutordiscovery/patches/local-docker-compose-dev-services
@@ -4,6 +4,10 @@ discovery:
   command: ./manage.py runserver 0.0.0.0:8381
   stdin_open: true
   tty: true
+  volumes:
+    {%- for mount in iter_mounts(MOUNTS, "discovery") %}
+    - {{ mount }}
+    {%- endfor %}
   ports:
     - "8381:8381"
   networks:


### PR DESCRIPTION
This PR is adding the ability to do a local development for course-discovery.

How to test:

```
tutor mounts add ./src/course-discovery
cat root/env/dev/docker-compose.yml
tutor dev start -d discovery
```