### PR TITLE
fix: Create media directory in Dockerfile.

### DIFF
--- a/changelog.d/20240412_140658_andres.md
+++ b/changelog.d/20240412_140658_andres.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix the docker image to allow media files to be served by uwsgi. (by @angonz)

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -73,6 +73,9 @@ RUN python manage.py compilemessages
 COPY --chown=app:app assets.py ./course_discovery/settings/assets.py
 RUN DJANGO_SETTINGS_MODULE=course_discovery.settings.assets make static
 
+# Create media directory to serve media files
+RUN mkdir course_discovery/media
+
 # Run production server
 ENV DJANGO_SETTINGS_MODULE course_discovery.settings.tutor.production
 EXPOSE 8000


### PR DESCRIPTION
If the media directory does not exist at the time that uwsgi is launched, the mapping to /media to serve
media files will not be created.

See issue #69 