### PR TITLE
Fix: images does not persist issue

### DIFF
--- a/changelog.d/20240626_115731_faraz.maqsood_images_persistance_issue.md
+++ b/changelog.d/20240626_115731_faraz.maqsood_images_persistance_issue.md
@@ -1,0 +1,1 @@
+- [BugFix] Fix images(media) persistance issue by mounting media directory in volumes through patches. (by @Faraz32123)

--- a/tutordiscovery/patches/local-docker-compose-dev-services
+++ b/tutordiscovery/patches/local-docker-compose-dev-services
@@ -5,7 +5,7 @@ discovery:
   stdin_open: true
   tty: true
   volumes:
-    - ../../data/discovery-media:/openedx/discovery/course_discovery/media
+    - ../../data/discovery/media:/openedx/discovery/course_discovery/media
   {%- for mount in iter_mounts(MOUNTS, "discovery") %}
     - {{ mount }}
   {%- endfor %}

--- a/tutordiscovery/patches/local-docker-compose-dev-services
+++ b/tutordiscovery/patches/local-docker-compose-dev-services
@@ -4,8 +4,9 @@ discovery:
   command: ./manage.py runserver 0.0.0.0:8381
   stdin_open: true
   tty: true
-  {%- for mount in iter_mounts(MOUNTS, "discovery") %}
   volumes:
+    - ../../data/discovery-media:/openedx/discovery/course_discovery/media
+  {%- for mount in iter_mounts(MOUNTS, "discovery") %}
     - {{ mount }}
   {%- endfor %}
   ports:

--- a/tutordiscovery/patches/local-docker-compose-services
+++ b/tutordiscovery/patches/local-docker-compose-services
@@ -5,6 +5,7 @@ discovery:
   restart: unless-stopped
   volumes:
     - ../plugins/discovery/apps/settings/tutor:/openedx/discovery/course_discovery/settings/tutor:ro
+    - ../../data/discovery-media:/openedx/discovery/course_discovery/media
   depends_on: 
     - lms
     {% if RUN_MYSQL %}- mysql{% endif %}

--- a/tutordiscovery/patches/local-docker-compose-services
+++ b/tutordiscovery/patches/local-docker-compose-services
@@ -5,7 +5,7 @@ discovery:
   restart: unless-stopped
   volumes:
     - ../plugins/discovery/apps/settings/tutor:/openedx/discovery/course_discovery/settings/tutor:ro
-    - ../../data/discovery-media:/openedx/discovery/course_discovery/media
+    - ../../data/discovery/media:/openedx/discovery/course_discovery/media
   depends_on: 
     - lms
     {% if RUN_MYSQL %}- mysql{% endif %}

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -86,10 +86,7 @@ COPY --chown=app:app assets.py ./course_discovery/settings/assets.py
 RUN DJANGO_SETTINGS_MODULE=course_discovery.settings.assets make static
 
 # Create media directory to serve media files
-# have to change user at this step, as it gives permission error
-User app
 RUN mkdir course_discovery/media
-User root
 
 # Run production server
 ENV DJANGO_SETTINGS_MODULE=course_discovery.settings.tutor.production

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -86,7 +86,10 @@ COPY --chown=app:app assets.py ./course_discovery/settings/assets.py
 RUN DJANGO_SETTINGS_MODULE=course_discovery.settings.assets make static
 
 # Create media directory to serve media files
+# have to change user at this step, as it gives permission error
+User app
 RUN mkdir course_discovery/media
+User root
 
 # Run production server
 ENV DJANGO_SETTINGS_MODULE=course_discovery.settings.tutor.production


### PR DESCRIPTION
Images were getting disappeared from discovery.
Reproduced this issue by 
- stopping discovery container
- deleting the container
- starting it again
Reason: Media root/directory wasn't added in the volumes.