### PR TITLE
fix: pathway API permissions

### DIFF
--- a/changelog.d/20240710_160247_evgen.dyudyunov_fix_service_user_permissions.md
+++ b/changelog.d/20240710_160247_evgen.dyudyunov_fix_service_user_permissions.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix catalog_service_user permissions and 403 while fetching pathways (by @dyudyunov)

--- a/tutordiscovery/templates/discovery/tasks/lms/init
+++ b/tutordiscovery/templates/discovery/tasks/lms/init
@@ -7,7 +7,7 @@
   get_user_model().objects.filter(username='lms_catalog_service_user').exclude(email='lms_catalog_service_user@openedx').update(email='lms_catalog_service_user@openedx')"
 
 ./manage.py lms manage_user discovery discovery@openedx --staff --superuser --unusable-password
-./manage.py lms manage_user lms_catalog_service_user lms_catalog_service_user@openedx --unusable-password
+./manage.py lms manage_user lms_catalog_service_user lms_catalog_service_user@openedx --staff --unusable-password
 
 # Development client
 ./manage.py lms create_dot_application \


### PR DESCRIPTION
Grant staff permissions to the catalog_service_user to
fix 403 error during the pathways fetching.

Note: this issue is also described in the readme.

Related discussions:
- https://discuss.openedx.org/t/tutor-discovery-service-api-v1-pathways-403/7995
- https://discuss.openedx.org/t/tutor-discovery-program-issue/10283Grant staff permissions to the catalog_service_user to
fix 403 error during the pathways fetching.

Note: this issue is also described in the readme.

Related discussions:
- https://discuss.openedx.org/t/tutor-discovery-service-api-v1-pathways-403/7995
- https://discuss.openedx.org/t/tutor-discovery-program-issue/10283