### PR TITLE
chore: move is_docker_rootless from tutor to tutor discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .DEFAULT_GOAL := help
 .PHONY: docs
-SRC_DIRS = ./tutordiscovery
+SRC_DIRS = ./tutordiscovery ./tests
 BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
 # Warning: These checks are run on every PR.
-test: test-lint test-types test-format  # Run some static checks.
+test: test-lint test-types test-format test-unit  # Run some static checks.
 
 test-format: ## Run code formatting tests.
 	black --check --diff $(BLACK_OPTS)
@@ -14,6 +14,9 @@ test-lint: ## Run code linting tests
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
+
+test-unit: ## Run unit tests
+	python -m unittest discover tests
 
 format: ## Format code automatically.
 	black $(BLACK_OPTS)

--- a/changelog.d/20241122_121506_faraz.maqsood_sumac.md
+++ b/changelog.d/20241122_121506_faraz.maqsood_sumac.md
@@ -1,0 +1,1 @@
+- [Improvement] Move is_docker_rootless method related to elasticsearch from tutor core to tutor-discovery. (by @Faraz32123)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tutordiscovery import utils
+
+
+class UtilsTests(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_is_docker_rootless(self, mock_run: MagicMock) -> None:
+        # Mock rootless `docker info` output
+        utils.is_docker_rootless.cache_clear()
+        mock_run.return_value.stdout = "some prefix\n rootless foo bar".encode("utf-8")
+        self.assertTrue(utils.is_docker_rootless())
+
+        # Mock regular `docker info` output
+        utils.is_docker_rootless.cache_clear()
+        mock_run.return_value.stdout = "some prefix, regular docker".encode("utf-8")
+        self.assertFalse(utils.is_docker_rootless())
+
+    @patch("subprocess.run")
+    def test_is_docker_rootless_podman(self, mock_run: MagicMock) -> None:
+        """Test the `is_docker_rootless` when podman is used or any other error with `docker info`"""
+        utils.is_docker_rootless.cache_clear()
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker info")
+        self.assertFalse(utils.is_docker_rootless())

--- a/tutordiscovery/plugin.py
+++ b/tutordiscovery/plugin.py
@@ -9,6 +9,7 @@ from tutor import hooks as tutor_hooks
 from tutor.__about__ import __version_suffix__
 
 from .__about__ import __version__
+from .utils import is_docker_rootless
 
 # Handle version suffix in nightly mode, just like tutor core
 if __version_suffix__:
@@ -126,6 +127,10 @@ tutor_hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
         ("discovery/build", "plugins"),
         ("discovery/apps", "plugins"),
     ],
+)
+# Template variables
+tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_item(
+    ("is_docker_rootless", is_docker_rootless),
 )
 # Load patches from files
 for path in glob(

--- a/tutordiscovery/utils.py
+++ b/tutordiscovery/utils.py
@@ -1,0 +1,16 @@
+import subprocess
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def is_docker_rootless() -> bool:
+    """
+    A helper function to determine if Docker is running in rootless mode.
+
+     - https://docs.docker.com/engine/security/rootless/
+    """
+    try:
+        results = subprocess.run(["docker", "info"], capture_output=True, check=True)
+        return "rootless" in results.stdout.decode()
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
- move is_docker_rootless method from tutor to tutor-discovery
- move is_docker_rootless related tests from tutor to tutor-discovery and modify makefile according to it.