### PR TITLE
Enhancement: add support for consuming events from event bus in discovery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,16 @@ This entry may be present if you named your server with the LMS hostname.
 
 .. _DigitalOcean: https://digitalocean.com/
 
+
+Using event-bus with tutor-discovery
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although tutor-discovery does not start event bus consumption by default, it supports running it. To consume events from event bus with tutor-discovery, follow these `instructions`_ provided by `event-bus-redis`_.
+
+.. _instructions: https://github.com/openedx/event-bus-redis/blob/main/docs/tutor_installation.rst
+.. _event-bus-redis: https://github.com/openedx/event-bus-redis
+
+
 Troubleshooting
 ---------------
 

--- a/changelog.d/20250108_184343_faraz.maqsood_add_support_for_consuming_events_from_event_bus.md
+++ b/changelog.d/20250108_184343_faraz.maqsood_add_support_for_consuming_events_from_event_bus.md
@@ -1,0 +1,1 @@
+- [Bugfix] Add support to consume events from event bus in discovery. Explanation can be viewed here: https://github.com/openedx/event-bus-redis/blob/main/docs/tutor_installation.rst. (by @Faraz32123)

--- a/tutordiscovery/templates/discovery/build/discovery/Dockerfile
+++ b/tutordiscovery/templates/discovery/build/discovery/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt update && \
     apt install -y curl git-core gettext language-pack-en \
     build-essential libcairo2 libffi-dev libmysqlclient-dev libxml2-dev libxslt-dev libjpeg-dev libssl-dev \
-    pkg-config libsqlite3-dev media-types mailcap
+    pkg-config libsqlite3-dev media-types mailcap libbz2-dev liblzma-dev
 ENV LC_ALL=en_US.UTF-8
 
 ARG APP_USER_ID=1000


### PR DESCRIPTION
- add support to consume events from event bus in discovery. Explanation can be viewed here: https://github.com/openedx/event-bus-redis/blob/main/docs/tutor_installation.rst
- close https://github.com/overhangio/tutor-discovery/issues/94