### PR TITLE
chore: replace site-configuration script with management command

### DIFF
--- a/changelog.d/20250324_230121_danyal.faheem_remove_site_configuration_script.md
+++ b/changelog.d/20250324_230121_danyal.faheem_remove_site_configuration_script.md
@@ -1,1 +1,1 @@
-[Improvement] Replace site-configuration script with create_or_update_site_configuration management command in the init task. (by @Danyal-Faheem)
+- [Improvement] Replace site-configuration script with create_or_update_site_configuration management command in the init task. (by @Danyal-Faheem)

--- a/changelog.d/20250324_230121_danyal.faheem_remove_site_configuration_script.md
+++ b/changelog.d/20250324_230121_danyal.faheem_remove_site_configuration_script.md
@@ -1,0 +1,1 @@
+[Improvement] Replace site-configuration script with create_or_update_site_configuration management command in the init task. (by @Danyal-Faheem)

--- a/tutordiscovery/templates/discovery/tasks/lms/init
+++ b/tutordiscovery/templates/discovery/tasks/lms/init
@@ -62,5 +62,5 @@
 # configuration -- which means that it takes different values for different
 # sites. This is important because the programs and courses returned for each
 # site will differ.
-site-configuration set -d {{ LMS_HOST }} COURSE_CATALOG_API_URL {% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST }}/api/v1
-site-configuration set -d {{ LMS_HOST }}:8000 COURSE_CATALOG_API_URL http://{{ DISCOVERY_HOST }}:8381/api/v1
+./manage.py lms create_or_update_site_configuration {{ LMS_HOST }} --configuration '{"COURSE_CATALOG_API_URL": "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST }}/api/v1"}' --enabled
+./manage.py lms create_or_update_site_configuration {{ LMS_HOST }}:8000 --configuration '{"COURSE_CATALOG_API_URL": "http://{{ DISCOVERY_HOST }}:8381/api/v1"}' --enabled


### PR DESCRIPTION
Fixes part of https://github.com/overhangio/tutor/issues/1207.

The site-configuration script was used to set the value of the COURSE_CATALOG_API_URL.
However, this script is being removed in tutor core as it is no longer required.
For this reason, we migrate to the provided [create_or_update_site_configuration](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py) management command in edx-platform.