### PR TITLE
fix: add CELERY_BROKER_URL for celery tasks to work

### DIFF
--- a/changelog.d/20260127_144108_faraz.maqsood_celery_tasks_failure_due_to_empty_broker_url.md
+++ b/changelog.d/20260127_144108_faraz.maqsood_celery_tasks_failure_due_to_empty_broker_url.md
@@ -1,0 +1,1 @@
+- [Bugfix] Add CELERY_BROKER_URL settings as celery tasks were failing due to empty celery broker url. (by @Faraz32123)

--- a/tutordiscovery/templates/discovery/apps/settings/partials/common.py
+++ b/tutordiscovery/templates/discovery/apps/settings/partials/common.py
@@ -104,5 +104,6 @@ EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
 EVENT_BUS_REDIS_CONNECTION_URL = 'redis://@redis:6379/'
 EVENT_BUS_TOPIC_PREFIX = 'dev'
 EVENT_BUS_CONSUMER = 'edx_event_bus_redis.RedisEventConsumer'
+CELERY_BROKER_URL = 'redis://redis:6379/'
 
 {{ patch("discovery-common-settings") }}


### PR DESCRIPTION
Add CELERY_BROKER_URL settings as celery tasks were failing due to empty celery broker url.
close #113.